### PR TITLE
Add daily language view (FR/ES words by day)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,9 +1080,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1098,9 +1095,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1118,9 +1112,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1136,9 +1127,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1156,9 +1144,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1174,9 +1159,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1194,9 +1176,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1213,9 +1192,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1231,9 +1207,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1257,9 +1230,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1281,9 +1251,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1307,9 +1274,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1331,9 +1295,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1357,9 +1318,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1382,9 +1340,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1406,9 +1361,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1776,9 +1728,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1794,9 +1743,6 @@
       "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1814,9 +1760,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,9 +1775,6 @@
       "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2150,9 +2090,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2170,9 +2107,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2190,9 +2124,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,9 +2141,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2850,9 +2778,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,9 +2792,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2806,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2820,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2834,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2935,9 +2848,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2952,9 +2862,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2969,9 +2876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6681,9 +6585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6705,9 +6606,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6729,9 +6627,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6753,9 +6648,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/DailyLanguageView.tsx
+++ b/src/components/DailyLanguageView.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, Volume2, ChevronDown, ChevronUp } from "lucide-react";
+import { speak } from "@/lib/tts";
+import type { Word } from "@/data/words";
+
+const DAY_TITLES: { es: string; fr: string }[] = [
+  { es: "Supervivencia", fr: "Survie" },
+  { es: "Comida y Casa", fr: "Nourriture et Maison" },
+  { es: "Cuerpo y Ropa", fr: "Corps et Vêtements" },
+  { es: "Mundo y Viajes", fr: "Monde et Voyages" },
+  { es: "Trabajo y Estudio", fr: "Travail et Études" },
+  { es: "Gente y Sociedad", fr: "Gens et Société" },
+  { es: "Verbos y Adjetivos", fr: "Verbes et Adjectifs" },
+];
+
+interface DailyLanguageViewProps {
+  words: Word[];
+  learned: Set<string>;
+  onBack: () => void;
+}
+
+export function DailyLanguageView({ words, learned, onBack }: DailyLanguageViewProps) {
+  const [selectedDay, setSelectedDay] = useState(0);
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+
+  const dayWords = useMemo(
+    () => words.filter((w) => w.day === selectedDay),
+    [words, selectedDay]
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Word[]>();
+    for (const w of dayWords) {
+      const existing = map.get(w.category);
+      if (existing) {
+        existing.push(w);
+      } else {
+        map.set(w.category, [w]);
+      }
+    }
+    return map;
+  }, [dayWords]);
+
+  const toggleCategory = (cat: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) {
+        next.delete(cat);
+      } else {
+        next.add(cat);
+      }
+      return next;
+    });
+  };
+
+  const learnedInDay = dayWords.filter((w) => learned.has(w.fr)).length;
+
+  // Expand all categories by default when changing days
+  const allExpanded = expandedCategories.size === 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack} className="rounded-xl">
+          <ArrowLeft className="w-4 h-4 mr-1" /> Volver
+        </Button>
+        <h2 className="text-lg font-bold text-gray-800">Palabras del Día</h2>
+      </div>
+
+      {/* Day selector pills */}
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {DAY_TITLES.map((title, i) => {
+          const count = words.filter((w) => w.day === i).length;
+          if (count === 0) return null;
+          return (
+            <button
+              key={i}
+              onClick={() => {
+                setSelectedDay(i);
+                setExpandedCategories(new Set());
+              }}
+              className={`flex-shrink-0 px-3 py-2 rounded-xl text-sm font-semibold transition-colors ${
+                selectedDay === i
+                  ? "bg-teal-500 text-white shadow-md"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+            >
+              D{i}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Day header */}
+      <Card className="rounded-2xl border-2 border-teal-100 shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            <p className="font-bold text-gray-800">
+              Día {selectedDay}: {DAY_TITLES[selectedDay].es}
+            </p>
+            <p className="text-sm italic text-teal-500 mt-0.5">
+              Jour {selectedDay} : {DAY_TITLES[selectedDay].fr}
+            </p>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <p className="text-sm text-gray-500">
+            {dayWords.length} palabras &bull; {learnedInDay} aprendidas
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Word list grouped by category */}
+      <div className="space-y-3">
+        {Array.from(grouped.entries()).map(([category, catWords]) => {
+          const isOpen = allExpanded || expandedCategories.has(category);
+          return (
+            <div key={category} className="rounded-xl border border-gray-200 overflow-hidden">
+              <button
+                onClick={() => toggleCategory(category)}
+                className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors"
+              >
+                <span className="text-sm font-bold text-gray-700 capitalize">
+                  {category}{" "}
+                  <span className="text-gray-400 font-normal">({catWords.length})</span>
+                </span>
+                {isOpen ? (
+                  <ChevronUp className="w-4 h-4 text-gray-400" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-gray-400" />
+                )}
+              </button>
+              {isOpen && (
+                <div className="divide-y divide-gray-100">
+                  {catWords.map((word) => (
+                    <div
+                      key={word.fr}
+                      className={`flex items-center gap-3 px-4 py-2.5 ${
+                        learned.has(word.fr) ? "bg-emerald-50/50" : ""
+                      }`}
+                    >
+                      <button
+                        onClick={() => speak(word.fr)}
+                        className="flex-shrink-0 p-1.5 rounded-lg text-teal-500 hover:bg-teal-50 transition-colors"
+                        aria-label={`Escuchar ${word.fr}`}
+                      >
+                        <Volume2 className="w-4 h-4" />
+                      </button>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-gray-800 truncate">
+                          {word.fr}
+                        </p>
+                        <p className="text-sm text-gray-500 truncate">{word.es}</p>
+                      </div>
+                      {learned.has(word.fr) && (
+                        <span className="flex-shrink-0 text-xs font-semibold text-emerald-500">
+                          ✓
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DayPlanner.tsx
+++ b/src/components/DayPlanner.tsx
@@ -360,6 +360,13 @@ export function DayPlanner({ tab }: DayPlannerProps) {
         <p className="text-sm font-bold text-gray-500 uppercase tracking-wider px-1">
           Herramientas
         </p>
+        <Button
+          variant="outline"
+          className="w-full min-h-[56px] justify-start text-base font-semibold rounded-xl border-2 border-teal-200 bg-teal-50 text-teal-700 hover:bg-teal-100"
+          onClick={() => setActiveModule({ type: "daily-language" })}
+        >
+          <Languages className="w-5 h-5 mr-2 text-teal-500" /> Palabras del Día (FR / ES)
+        </Button>
         <div className="grid grid-cols-2 gap-3">
           <Button
             variant="outline"
@@ -410,13 +417,6 @@ export function DayPlanner({ tab }: DayPlannerProps) {
           onClick={() => setActiveModule({ type: "listening" })}
         >
           <Headphones className="w-5 h-5 mr-2 text-blue-500" /> Guía de Escucha
-        </Button>
-        <Button
-          variant="outline"
-          className="w-full min-h-[56px] justify-start text-base font-semibold rounded-xl border-2 border-teal-200 bg-teal-50 text-teal-700 hover:bg-teal-100"
-          onClick={() => setActiveModule({ type: "daily-language" })}
-        >
-          <Languages className="w-5 h-5 mr-2 text-teal-500" /> Palabras del Día (FR / ES)
         </Button>
       </div>
 

--- a/src/components/DayPlanner.tsx
+++ b/src/components/DayPlanner.tsx
@@ -15,6 +15,7 @@ import { SpeakingB } from "./SpeakingB";
 import { WriteEmail } from "./WriteEmail";
 import { WriteOpinion } from "./WriteOpinion";
 import { ListenGuide } from "./ListenGuide";
+import { DailyLanguageView } from "./DailyLanguageView";
 import { useLearnedWords } from "@/hooks/useLearnedWords";
 import { useProgress } from "@/hooks/useProgress";
 import { words as allWordData } from "@/data/words";
@@ -41,6 +42,7 @@ import {
   Mail,
   FileText,
   Headphones,
+  Languages,
 } from "lucide-react";
 import type { DayPlan } from "@/data/plan-clb5";
 
@@ -53,7 +55,8 @@ type ActiveModule =
   | { type: "speaking-b" }
   | { type: "write-email" }
   | { type: "write-opinion" }
-  | { type: "listening" };
+  | { type: "listening" }
+  | { type: "daily-language" };
 
 interface DayPlannerProps {
   tab: "clb5" | "clb7";
@@ -251,6 +254,14 @@ export function DayPlanner({ tab }: DayPlannerProps) {
         );
       case "listening":
         return <ListenGuide tab={tab} onBack={handleBack} />;
+      case "daily-language":
+        return (
+          <DailyLanguageView
+            words={tabWords}
+            learned={learned}
+            onBack={handleBack}
+          />
+        );
     }
   }
 
@@ -399,6 +410,13 @@ export function DayPlanner({ tab }: DayPlannerProps) {
           onClick={() => setActiveModule({ type: "listening" })}
         >
           <Headphones className="w-5 h-5 mr-2 text-blue-500" /> Guía de Escucha
+        </Button>
+        <Button
+          variant="outline"
+          className="w-full min-h-[56px] justify-start text-base font-semibold rounded-xl border-2 border-teal-200 bg-teal-50 text-teal-700 hover:bg-teal-100"
+          onClick={() => setActiveModule({ type: "daily-language" })}
+        >
+          <Languages className="w-5 h-5 mr-2 text-teal-500" /> Palabras del Día (FR / ES)
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds a new "Palabras del Día (FR / ES)" view showing all French and Spanish words organized by vocabulary day (0-6)
- Words grouped by category with collapsible sections, TTS pronunciation, and learned word indicators
- Button placed at the top of the Herramientas section for easy access

## Test plan
- [ ] Verify the teal "Palabras del Día (FR / ES)" button appears in the Herramientas section
- [ ] Click through each day (D0-D6) and confirm words display correctly
- [ ] Test TTS speaker button plays French pronunciation
- [ ] Verify learned words show green highlight and checkmark
- [ ] Test on both CLB5 and CLB7 tabs

https://claude.ai/code/session_01VF8unA81mNx3gPfLxkyLbX